### PR TITLE
Fix variable shadowing in new_path_with_id

### DIFF
--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -321,7 +321,7 @@ impl PathConnectionIdentifiers {
                 initialized_source_connection_id
         );
 
-        let reset_token = initial_scid.as_ref().and(reset_token);
+        let reset_token_scid = initial_scid.as_ref().and(reset_token);
         // We need to track up to (2 * source_conn_id_limit - 1) source
         // Connection IDs when the host wants to force their renewal.
         let scids = BoundedNonEmptyVecDeque::new(
@@ -329,18 +329,18 @@ impl PathConnectionIdentifiers {
             ConnectionIdEntry {
                 cid: initial_scid.unwrap_or_default(),
                 seq: 0,
-                reset_token,
+                reset_token: reset_token_scid,
                 network_path,
             },
         );
 
-        let reset_token = initial_dcid.as_ref().and(reset_token);
+        let reset_token_dcid = initial_dcid.as_ref().and(reset_token);
         let dcids = BoundedNonEmptyVecDeque::new(
             destination_conn_id_limit,
             ConnectionIdEntry {
                 cid: initial_dcid.unwrap_or_default(),
                 seq: 0,
-                reset_token,
+                reset_token: reset_token_dcid,
                 network_path,
             },
         );


### PR DESCRIPTION
In the current version, whenever a scid is None when calling new_with_path_id, the reset token associated to a dcid is also set to None, even if it had a value before. This leads to errors in the verification of the CID if a NEW_PATH_CONNECTION_ID is retransmitted (e.g.: because it was lost), as reset tokens differs.

This patch fixes this issue by deleting the variable shadowing.